### PR TITLE
miniz.c: extract a single file to heap from a memory buffer

### DIFF
--- a/miniz.c
+++ b/miniz.c
@@ -4875,7 +4875,32 @@ void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename, const char 
   mz_zip_reader_end(&zip_archive);
   return p;
 }
+	  
+void *mz_zip_extract_archive_file_to_heap_from_buffer(const void *zipBuffer, size_t zipBufferSize, const char *pArchive_name, size_t *pSize, mz_uint flags)
+{
+  int file_index;
+  mz_zip_archive zip_archive;
+  void *p = NULL;
 
+  if (pSize)
+    *pSize = 0;
+	
+  if ((!zipBuffer) || (!zipBufferSize))
+    return NULL;
+
+  if (!pArchive_name)
+    return NULL;
+
+  MZ_CLEAR_OBJ(zip_archive);
+  if (!mz_zip_reader_init_mem(&zip_archive, zipBuffer, zipBufferSize, flags | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY))
+    return NULL;
+
+  if ((file_index = mz_zip_reader_locate_file(&zip_archive, pArchive_name, NULL, flags)) >= 0)
+    p = mz_zip_reader_extract_to_heap(&zip_archive, file_index, pSize, flags);
+
+  mz_zip_reader_end(&zip_archive);
+  return p;
+}
 #endif // #ifndef MINIZ_NO_STDIO
 
 #endif // #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS


### PR DESCRIPTION
The new function **mz_zip_extract_archive_file_to_heap_from_buffer** does the same as **mz_zip_extract_archive_file_to_heap**. Instead of dealing directly with a file path it does the proper thing with a memory buffer. It is useful when the contents of a file were already loaded in memory, avoiding the redundant action of loading the file again, hence saving precious time.