### PR TITLE
Iterative decompression

### DIFF
--- a/miniz_zip.h
+++ b/miniz_zip.h
@@ -174,6 +174,26 @@ typedef struct
 
 } mz_zip_archive;
 
+typedef struct
+{
+    mz_zip_archive *pZip;
+    mz_uint flags;
+
+    int status;
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+    mz_uint file_crc32;
+#endif
+    mz_uint64 read_buf_size, read_buf_ofs, read_buf_avail, comp_remaining, out_buf_ofs, cur_file_ofs;
+    mz_zip_archive_file_stat file_stat;
+    void *pRead_buf;
+    void *pWrite_buf;
+
+    size_t out_blk_remain;
+
+    tinfl_decompressor inflator;
+
+} mz_zip_reader_extract_iter_state;
+
 /* -------- ZIP reading */
 
 /* Inits a ZIP archive reader. */
@@ -280,6 +300,12 @@ void *mz_zip_reader_extract_file_to_heap(mz_zip_archive *pZip, const char *pFile
 /* Extracts a archive file using a callback function to output the file's data. */
 mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_index, mz_file_write_func pCallback, void *pOpaque, mz_uint flags);
 mz_bool mz_zip_reader_extract_file_to_callback(mz_zip_archive *pZip, const char *pFilename, mz_file_write_func pCallback, void *pOpaque, mz_uint flags);
+
+/* Extract a file iteratively */
+mz_zip_reader_extract_iter_state* mz_zip_reader_extract_iter_new(mz_zip_archive *pZip, mz_uint file_index, mz_uint flags);
+mz_zip_reader_extract_iter_state* mz_zip_reader_extract_file_iter_new(mz_zip_archive *pZip, const char *pFilename, mz_uint flags);
+size_t mz_zip_reader_extract_iter_read(mz_zip_reader_extract_iter_state* pState, void* pvBuf, size_t buf_size);
+mz_bool mz_zip_reader_extract_iter_free(mz_zip_reader_extract_iter_state* pState);
 
 #ifndef MINIZ_NO_STDIO
 /* Extracts a archive file to a disk file and sets its last accessed and modified times. */


### PR DESCRIPTION
Hi,

Great little library, been using it for some prototyping on an embedded platform recently.

Had a need to extract large files (3-5MB...on an embedded system) from a zip directly to a waiting web server client.

Callback method was a good start but network stack memory usage became an issue.

Therefore I've written an iterative decompression method, allowing a file to be decompressed in variable sized chunks - allowing me to load small chunks at a time into my socket as the TCP buffers empty.

I've based it heavily on the callback method.

A state instance (containing the variables which were on the stack before with the callback extractor) can be created with mz_zip_reader_extract_iter_new or mz_zip_reader_extract_file_iter_new.

Once constructed the compressed file can be read either compressed or decompressed via mz_zip_reader_extract_iter_read.

Finally the state object can be destroyed via mz_zip_reader_extract_iter_free.

I've included a few tests for it in the tests directory. The build passes with the different combinations of flag tested in test.sh.

I've also tested it extensively myself, with gcov and valgrind.

I've tested both zips hosted in memory (my use case....directly from Flash) as well as zips being loaded from files. I've checked it gracefully handles empty files and directories...passed either by index or by name.

Love to see it included,

Keep up the good work!

Phil