### PR TITLE
Don't warn if _LARGEFILE64_SOURCE is not defined

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -97,7 +97,7 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN(f, m, s) freopen(f, m, s)
 #define MZ_DELETE_FILE remove
-#elif defined(__GNUC__) && _LARGEFILE64_SOURCE
+#elif defined(__GNUC__) && defined(_LARGEFILE64_SOURCE) && _LARGEFILE64_SOURCE
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif


### PR DESCRIPTION
Such a warning is otherwise shown with GCC if -Wundef is used. That's the only warning I got for this code when I dropped it into our codebase (nice!), and it'd be nice if we could just compile it with the same warnings as the rest of our code.