### PR TITLE
guard memcpy when n == 0 because buffer may be NULL

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -351,7 +351,8 @@ static MZ_FORCEINLINE mz_bool mz_zip_array_push_back(mz_zip_archive *pZip, mz_zi
     size_t orig_size = pArray->m_size;
     if (!mz_zip_array_resize(pZip, pArray, orig_size + n, MZ_TRUE))
         return MZ_FALSE;
-    memcpy((mz_uint8 *)pArray->m_p + orig_size * pArray->m_element_size, pElements, n * pArray->m_element_size);
+    if (n > 0)
+        memcpy((mz_uint8 *)pArray->m_p + orig_size * pArray->m_element_size, pElements, n * pArray->m_element_size);
     return MZ_TRUE;
 }
 


### PR DESCRIPTION
Sometimes miniz will call this function with pElements == 0 when n == 0. However, memcpy technically requires the pointers to be valid to write to even if n == 0 (https://stackoverflow.com/questions/5243012/is-it-guaranteed-to-be-safe-to-perform-memcpy0-0-0). This is causing AddressSanitizer (ASAN) failures in our use case.