### PR TITLE
Fix a MSVC 2013 warning

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -2000,7 +2000,7 @@ size_t mz_zip_reader_extract_iter_read(mz_zip_reader_extract_iter_state* pState,
     if ((pState->flags & MZ_ZIP_FLAG_COMPRESSED_DATA) || (!pState->file_stat.m_method))
     {
         /* The file is stored or the caller has requested the compressed data, calc amount to return. */
-        copied_to_caller = MZ_MIN( buf_size, pState->comp_remaining );
+        copied_to_caller = (size_t)MZ_MIN( buf_size, pState->comp_remaining );
 
         /* Zip is in memory....or requires reading from a file? */
         if (pState->pZip->m_pState->m_pMem)


### PR DESCRIPTION
 Hi.  While trying to make [C-Blosc2](https://github.com/Blosc/c-blosc2) as free of warnings as possible I fixed a fall-through warning in miniz (2.0.8) that only shows up in MSVC (at least 2013 and 2015 versions) when compiling in 32-bit mode (in 64-bit the issue does not show-up). The root of the problem seems to be that in this mode, `size_t` is 32-bit and receiving data from `mz_uint64` may result in a 'data loss'.

I think the warning is meaningful.  In case you don't think this represents an actual issue, this PR just does a cast for making the warning go away.