### PR TITLE
Add !defined check on MINIZ_USE_ALIGNED_LOADS_AND_STORES

### DIFF
--- a/miniz.h
+++ b/miniz.h
@@ -170,12 +170,15 @@
 #define MINIZ_LITTLE_ENDIAN 0
 #endif
 
+/* Set MINIZ_USE_UNALIGNED_LOADS_AND_STORES only if not set */
+#if !defined(MINIZ_USE_UNALIGNED_LOADS_AND_STORES)
 #if MINIZ_X86_OR_X64_CPU
 /* Set MINIZ_USE_UNALIGNED_LOADS_AND_STORES to 1 on CPU's that permit efficient integer loads and stores from unaligned addresses. */
 #define MINIZ_USE_UNALIGNED_LOADS_AND_STORES 1
 #define MINIZ_UNALIGNED_USE_MEMCPY
 #else
 #define MINIZ_USE_UNALIGNED_LOADS_AND_STORES 0
+#endif
 #endif
 
 #if defined(_M_X64) || defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__) || defined(__ia64__) || defined(__x86_64__)


### PR DESCRIPTION
Add !defined check so that one can override by defining MINIZ_USE_ALIGNED_LOADS_AND_STORES in case a given compiler does not support it (this issue has been seen in the wild, see assimp/assimp#2389)
There isn't a contribution guide that I can find; please let me know if there's anything you want me to change. Also, I'm still testing this, but I can't imagine this compiler guard will cause issues.