### PR TITLE
CMake updates and CMake-based amalgamation step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,45 +8,103 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
 CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif ()
 
+option(BUILD_EXAMPLES "Build examples" ON)
+option(AMALGAMATE_SOURCES "Amalgamate sources into miniz.h/c" OFF)
+option(BUILD_HEADER_ONLY "Build a header-only version" OFF)
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 
-set(miniz_SOURCE miniz.c miniz_zip.c miniz_tinfl.c miniz_tdef.c)
+if(BUILD_HEADER_ONLY)
+  set(AMALGAMATE_SOURCES ON CACHE BOOL "Build a header-only version" FORCE)
+endif(BUILD_HEADER_ONLY)
 
-add_library(miniz ${miniz_SOURCE})
-target_include_directories(miniz PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+if(AMALGAMATE_SOURCES)
+  # Amalgamate
+  file(COPY miniz.h DESTINATION ${CMAKE_BINARY_DIR}/amalgamation/)
+  file(READ miniz.h MINIZ_H)
+  file(READ miniz_common.h MINIZ_COMMON_H)
+  file(READ miniz_tdef.h MINIZ_TDEF_H)
+  file(READ miniz_tinfl.h MINIZ_TINFL_H)
+  file(READ miniz_zip.h MINIZ_ZIP_H)
+  file(APPEND ${CMAKE_BINARY_DIR}/amalgamation/miniz.h
+     "${MINIZ_COMMON_H} ${MINIZ_TDEF_H} ${MINIZ_TINFL_H} ${MINIZ_ZIP_H}")
 
-set(EXAMPLE1_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example1.c")
-set(EXAMPLE2_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example2.c")
-set(EXAMPLE3_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example3.c")
-set(EXAMPLE4_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example4.c")
-set(EXAMPLE5_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example5.c")
-set(EXAMPLE6_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example6.c")
-set(MINIZ_TESTER_SRC_LIST
-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/miniz_tester.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/timer.cpp")
+  file(COPY miniz.c DESTINATION ${CMAKE_BINARY_DIR}/amalgamation/)
+  file(READ miniz_tdef.c MINIZ_TDEF_C)
+  file(READ miniz_tinfl.c MINIZ_TINFL_C)
+  file(READ miniz_zip.c MINIZ_ZIP_C)
+  file(APPEND ${CMAKE_BINARY_DIR}/amalgamation/miniz.c
+     "${MINIZ_TDEF_C} ${MINIZ_TINFL_C} ${MINIZ_ZIP_C}")
 
-add_executable(example1 ${EXAMPLE1_SRC_LIST})
-target_link_libraries(example1 miniz)
-add_executable(example2 ${EXAMPLE2_SRC_LIST})
-target_link_libraries(example2 miniz)
-add_executable(example3 ${EXAMPLE3_SRC_LIST})
-target_link_libraries(example3 miniz)
-add_executable(example4 ${EXAMPLE4_SRC_LIST})
-target_link_libraries(example4 miniz)
-add_executable(example5 ${EXAMPLE5_SRC_LIST})
-target_link_libraries(example5 miniz)
-add_executable(example6 ${EXAMPLE6_SRC_LIST})
-target_link_libraries(example6 miniz)
-if(${UNIX})
-    target_link_libraries(example6 m)
-endif()
-
-# add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
-# target_link_libraries(miniz_tester miniz)
-
-install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
-    ARCHIVE  DESTINATION lib
-    LIBRARY DESTINATION lib
+  file(READ ${CMAKE_BINARY_DIR}/amalgamation/miniz.h AMAL_MINIZ_H)
+  file(READ ${CMAKE_BINARY_DIR}/amalgamation/miniz.c AMAL_MINIZ_C)
+  foreach(REPLACE_STRING miniz;miniz_common;miniz_tdef;miniz_tinfl;miniz_zip)
+    string(REPLACE "#include \"${REPLACE_STRING}.h\"" "" AMAL_MINIZ_H "${AMAL_MINIZ_H}")
+    string(REPLACE "#include \"${REPLACE_STRING}.h\"" "" AMAL_MINIZ_C "${AMAL_MINIZ_C}")
+  endforeach()
+  if(BUILD_HEADER_ONLY)
+    string(CONCAT AMAL_MINIZ_H "${AMAL_MINIZ_H}" "\n#ifndef MINIZ_HEADER_FILE_ONLY\n"
+             "${AMAL_MINIZ_C}" "\n#endif // MINIZ_HEADER_FILE_ONLY\n")
+    file(WRITE ${CMAKE_BINARY_DIR}/amalgamation/miniz.h "${AMAL_MINIZ_H}")
+    add_library(${PROJECT_NAME} INTERFACE)
+    set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/amalgamation>
+      $<INSTALL_INTERFACE:include>
     )
-file(GLOB INSTALL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
-install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})
+  else(BUILD_HEADER_ONLY)
+    string(CONCAT AMAL_MINIZ_C "#include \"miniz.h\"\n" "${AMAL_MINIZ_C}")
+    file(WRITE ${CMAKE_BINARY_DIR}/amalgamation/miniz.h "${AMAL_MINIZ_H}")
+    file(WRITE ${CMAKE_BINARY_DIR}/amalgamation/miniz.c "${AMAL_MINIZ_C}")
+    set(miniz_SOURCE ${CMAKE_BINARY_DIR}/amalgamation/miniz.h
+                     ${CMAKE_BINARY_DIR}/amalgamation/miniz.c)
+    add_library(${PROJECT_NAME} ${miniz_SOURCE})
+    target_include_directories(${PROJECT_NAME} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/amalgamation>
+      $<INSTALL_INTERFACE:include>
+    )
+  endif(BUILD_HEADER_ONLY)
+  set(INSTALL_HEADERS ${CMAKE_BINARY_DIR}/amalgamation/miniz.h)
+else(AMALGAMATE_SOURCES)
+  set(miniz_SOURCE miniz.c miniz_zip.c miniz_tinfl.c miniz_tdef.c)
+  add_library(${PROJECT_NAME} ${miniz_SOURCE})
+  target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
+  file(GLOB INSTALL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+endif(AMALGAMATE_SOURCES)
+
+if(BUILD_EXAMPLES)
+  set(EXAMPLE1_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example1.c")
+  set(EXAMPLE2_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example2.c")
+  set(EXAMPLE3_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example3.c")
+  set(EXAMPLE4_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example4.c")
+  set(EXAMPLE5_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example5.c")
+  set(EXAMPLE6_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example6.c")
+  set(MINIZ_TESTER_SRC_LIST
+      "${CMAKE_CURRENT_SOURCE_DIR}/tests/miniz_tester.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/tests/timer.cpp")
+
+  add_executable(example1 ${EXAMPLE1_SRC_LIST})
+  target_link_libraries(example1 miniz)
+  add_executable(example2 ${EXAMPLE2_SRC_LIST})
+  target_link_libraries(example2 miniz)
+  add_executable(example3 ${EXAMPLE3_SRC_LIST})
+  target_link_libraries(example3 miniz)
+  add_executable(example4 ${EXAMPLE4_SRC_LIST})
+  target_link_libraries(example4 miniz)
+  add_executable(example5 ${EXAMPLE5_SRC_LIST})
+  target_link_libraries(example5 miniz)
+  add_executable(example6 ${EXAMPLE6_SRC_LIST})
+  target_link_libraries(example6 miniz)
+  if(${UNIX})
+      target_link_libraries(example6 m)
+  endif()
+
+  # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
+  # target_link_libraries(miniz_tester miniz)
+endif(BUILD_EXAMPLES)
+
+set(INCLUDE_INSTALL_DIR "include")
+
+install(FILES ${INSTALL_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}/${PROJECT_NAME})

--- a/amalgamate.sh
+++ b/amalgamate.sh
@@ -3,44 +3,30 @@
 set -e
 
 mkdir -p amalgamation
-OUTPUT_PREFIX=amalgamation/miniz
 
-cat miniz.h > $OUTPUT_PREFIX.h
-cat miniz.c > $OUTPUT_PREFIX.c
-cat miniz_common.h >> $OUTPUT_PREFIX.h
-cat miniz_tdef.c >> $OUTPUT_PREFIX.c
-cat miniz_tdef.h >> $OUTPUT_PREFIX.h
-cat miniz_tinfl.c >> $OUTPUT_PREFIX.c
-cat miniz_tinfl.h >> $OUTPUT_PREFIX.h
-cat miniz_zip.c >> $OUTPUT_PREFIX.c
-cat miniz_zip.h >> $OUTPUT_PREFIX.h
+OUTPUT_PREFIX=_build/amalgamation
 
-
-sed -i '0,/#include "miniz.h"/{s/#include "miniz.h"/#include  "miniz.h"/}' $OUTPUT_PREFIX.c
-for i in miniz miniz_common miniz_tdef miniz_tinfl miniz_zip
-do
-	sed -i "s/#include \"$i.h\"//g" $OUTPUT_PREFIX.h
-	sed -i "s/#include \"$i.h\"//g" $OUTPUT_PREFIX.c
-done
+cmake -H. -B_build -DAMALGAMATE_SOURCES=ON -G"Unix Makefiles"
 
 echo "int main() { return 0; }" > main.c
 echo "Test compile with GCC..."
-gcc -pedantic -Wall main.c $OUTPUT_PREFIX.c -o test.out
+gcc -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
 echo "Test compile with GCC ANSI..."
-gcc -ansi -pedantic -Wall main.c $OUTPUT_PREFIX.c -o test.out
+gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
 if command -v clang
 then
 		echo "Test compile with clang..."
-        clang -Wall -Wpedantic -fsanitize=unsigned-integer-overflow main.c $OUTPUT_PREFIX.c -o test.out
+        clang -Wall -Wpedantic -fsanitize=unsigned-integer-overflow -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
 fi
 for def in MINIZ_NO_STDIO MINIZ_NO_TIME MINIZ_NO_ARCHIVE_APIS MINIZ_NO_ARCHIVE_WRITING_APIS MINIZ_NO_ZLIB_APIS MINIZ_NO_ZLIB_COMPATIBLE_NAMES MINIZ_NO_MALLOC
 do
 	echo "Test compile with GCC and define $def..."
-	gcc -ansi -pedantic -Wall main.c $OUTPUT_PREFIX.c -o test.out -D${def}
+	gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -D${def}
 done
 rm test.out
 rm main.c
 
+cp $OUTPUT_PREFIX/miniz.* amalgamation/
 cp ChangeLog.md amalgamation/
 cp LICENSE amalgamation/
 cp readme.md amalgamation/

--- a/examples/example2.c
+++ b/examples/example2.c
@@ -13,7 +13,7 @@
 #endif
 
 #include <stdio.h>
-#include "miniz_zip.h"
+#include "miniz.h"
 
 typedef unsigned char uint8;
 typedef unsigned short uint16;

--- a/examples/example4.c
+++ b/examples/example4.c
@@ -1,6 +1,6 @@
 // example4.c - Uses tinfl.c to decompress a zlib stream in memory to an output file
 // Public domain, May 15 2011, Rich Geldreich, richgel99@gmail.com. See "unlicense" statement at the end of tinfl.c.
-#include "miniz_tinfl.h"
+#include "miniz.h"
 #include <stdio.h>
 #include <limits.h>
 


### PR DESCRIPTION
I wanted to generate the single `miniz.h` header in a cross-platform way, so I rewrote the amalgamation step in CMake. I also added options to toggle whether the build should proceed normally, use the amalgamated sources, or build the header-only version.

Examples that depended on the various individual headers I changed to depend on `miniz.h`, since they will fail to build when amalgamation or header-only options are specified.

To ensure the amalgamation logic is only in one place, I replaced the code from `amalgamate.sh` to use the CMake variant.

I will have a follow-up PR to set up the `EXPORT` file.

PTAL @uroni 