### PR TITLE
Add include location tolerance and stop forcing _GNU_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,11 @@ if(AMALGAMATE_SOURCES)
     file(WRITE ${CMAKE_BINARY_DIR}/amalgamation/miniz.h "${AMAL_MINIZ_H}")
     add_library(${PROJECT_NAME} INTERFACE)
     
-    target_compile_definitions(${PROJECT_NAME} 
-        INTERFACE $<$<C_COMPILER_ID:GNU>:_GNU_SOURCE>)
+    # Might not be a good idea to force this on the library user
+    # as it could bloat the global namespace
+    # https://github.com/libevent/libevent/issues/460
+    # target_compile_definitions(${PROJECT_NAME} 
+    #     INTERFACE $<$<C_COMPILER_ID:GNU>:_GNU_SOURCE>)
     
     set_property(TARGET ${PROJECT_NAME} APPEND 
       PROPERTY INTERFACE_INCLUDE_DIRECTORIES
@@ -131,7 +134,8 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
   RUNTIME  DESTINATION bin
   ARCHIVE  DESTINATION lib
   LIBRARY  DESTINATION lib
-  INCLUDES DESTINATION include
+  # users can use <miniz.h> or <miniz/miniz.h>
+  INCLUDES DESTINATION include include/${PROJECT_NAME}
   )
 
 include(CMakePackageConfigHelpers)

--- a/miniz_zip.h
+++ b/miniz_zip.h
@@ -210,7 +210,7 @@ MINIZ_EXPORT mz_bool mz_zip_reader_init_file(mz_zip_archive *pZip, const char *p
 MINIZ_EXPORT mz_bool mz_zip_reader_init_file_v2(mz_zip_archive *pZip, const char *pFilename, mz_uint flags, mz_uint64 file_start_ofs, mz_uint64 archive_size);
 
 /* Read an archive from an already opened FILE, beginning at the current file position. */
-/* The archive is assumed to be archive_size bytes long. If archive_size is < 0, then the entire rest of the file is assumed to contain the archive. */
+/* The archive is assumed to be archive_size bytes long. If archive_size is 0, then the entire rest of the file is assumed to contain the archive. */
 /* The FILE will NOT be closed when mz_zip_reader_end() is called. */
 MINIZ_EXPORT mz_bool mz_zip_reader_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint64 archive_size, mz_uint flags);
 #endif


### PR DESCRIPTION
One last pull request as I'm a bit concerned about forcing _GNU_SOURCE in header only mode. It might cause problems if a user would not like it to be defined. If explicit large file support is desired, one can still define _LARGEFILE64_SOURCE before including miniz.h (applies for header only amalgamated version).

Currently the include location after installing is <miniz/miniz.h>. I've included a small fix to make it work with <miniz.h> as well.

I also included a tiny fix for a doc comment which caused me a bit of confusion.