### PR TITLE
Fix LFS check

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -97,7 +97,7 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN(f, m, s) freopen(f, m, s)
 #define MZ_DELETE_FILE remove
-#elif defined(__GNUC__) && defined(_LARGEFILE64_SOURCE)
+#elif defined(__USE_LARGEFILE64) // gcc, clang
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif


### PR DESCRIPTION
Code should check for__USE_LARGEFILE64, not _LARGEFILE64_SOURCE

_LARGEFILE64_SOURCE should be used only for setting a preference
when compiling code (either explicitly or by the compiler itself).
Then, according to its value, features.h will take care of defining things
like __USE_LARGEFILE64 appropriately.

As a side-effect, this patch adds support for clang. When building
with clang one has to explicitly define _LARGEFILE64_SOURCE if he
wants to use the *64 api.