### PR TITLE
Add #elif to enable an external mz_crc32() to be linked in.

### DIFF
--- a/miniz.c
+++ b/miniz.c
@@ -82,6 +82,12 @@ mz_ulong mz_adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len)
         }
         return ~crcu32;
     }
+#elif defined(USE_EXTERNAL_MZCRC)
+/* If USE_EXTERNAL_CRC is defined, an external module will export the
+ * mz_crc32() symbol for us to use, e.g. an SSE-accelerated version.
+ * Depending on the impl, it may be necessary to ~ the input/output crc values.
+ */
+mz_ulong mz_crc32(mz_ulong crc, const mz_uint8 *ptr, size_t buf_len);
 #else
 /* Faster, but larger CPU cache footprint.
  */


### PR DESCRIPTION
Adds '#elif defined(USE_EXTERNAL_MZCRC)' by the mz_crc32() definition
to enable the option of a user linking in an alternate crc implementation.

The main reason why this might be desired would be to use an SSE-accelerated
crc implementaiton, which would be faster, but not be reasonable to include
in this file.