### PR TITLE
Fix unused parameter ‘pArray’ in mz_zip_array_range_check

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -277,7 +277,7 @@ struct mz_zip_internal_state_tag
 
 #define MZ_ZIP_ARRAY_SET_ELEMENT_SIZE(array_ptr, element_size) (array_ptr)->m_element_size = element_size
 
-#if defined(DEBUG) || defined(_DEBUG) || defined(NDEBUG)
+#if defined(DEBUG) || defined(_DEBUG)
 static MZ_FORCEINLINE mz_uint mz_zip_array_range_check(const mz_zip_array *pArray, mz_uint index)
 {
     MZ_ASSERT(index < pArray->m_size);


### PR DESCRIPTION
When NDEBUG, the assert in mz_zip_array_range_check does nothing and an unused variable warning is generated at https://github.com/richgel999/miniz/blob/4159f8c8c3d91a76648107ce6adf54bb6f06e3a7/miniz_zip.c#L280

This PR removes the `|| define (NDEBUG)` so when debugging is turned off, no range check is performed.