### PR TITLE
Add fuzz targets for OSS-Fuzz integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif ()
 
 option(BUILD_EXAMPLES "Build examples" ON)
+option(BUILD_FUZZERS "Build fuzz targets" OFF)
 option(AMALGAMATE_SOURCES "Amalgamate sources into miniz.h/c" OFF)
 option(BUILD_HEADER_ONLY "Build a header-only version" OFF)
 option(BUILD_SHARED_LIBS "Build shared library instead of static" ON)
@@ -201,6 +202,23 @@ if(BUILD_EXAMPLES)
   # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
   # target_link_libraries(miniz_tester miniz)
 endif(BUILD_EXAMPLES)
+
+if(BUILD_FUZZERS)
+  set(FUZZ_MAIN_SRC "${CMAKE_CURRENT_SOURCE_DIR}/tests/fuzz_main.c")
+
+  set(CHECKSUM_FUZZER_SRC_LIST "${FUZZ_MAIN_SRC}" "${CMAKE_CURRENT_SOURCE_DIR}/tests/checksum_fuzzer.c")
+  set(FLUSH_FUZZER_SRC_LIST "${FUZZ_MAIN_SRC}" "${CMAKE_CURRENT_SOURCE_DIR}/tests/flush_fuzzer.c")
+  set(UNCOMPRESS_FUZZER_SRC_LIST "${FUZZ_MAIN_SRC}" "${CMAKE_CURRENT_SOURCE_DIR}/tests/uncompress_fuzzer.c")
+
+  add_executable(checksum_fuzzer ${CHECKSUM_FUZZER_SRC_LIST})
+  target_link_libraries(checksum_fuzzer miniz)
+
+  add_executable(flush_fuzzer ${FLUSH_FUZZER_SRC_LIST})
+  target_link_libraries(flush_fuzzer miniz)
+
+  add_executable(uncompress_fuzzer ${UNCOMPRESS_FUZZER_SRC_LIST})
+  target_link_libraries(uncompress_fuzzer miniz)
+endif()
 
 set(INCLUDE_INSTALL_DIR "include")
 

--- a/tests/checksum_fuzzer.c
+++ b/tests/checksum_fuzzer.c
@@ -1,0 +1,25 @@
+/* Derived from zlib fuzzers at http://github.com/google/oss-fuzz/tree/master/projects/zlib,
+ * see ossfuzz.sh for full license text.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "miniz.h"
+
+static const size_t kMaxSize = 1024 * 1024;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen)
+{
+    /* Discard inputs larger than 1Mb. */
+    if (dataLen < 1 || dataLen > kMaxSize) return 0;
+
+    uint32_t crc = crc32(0L, NULL, 0);
+    uint32_t adler = adler32(0L, NULL, 0);
+
+    crc = crc32(crc, data, (uint32_t) dataLen);
+    adler = adler32(adler, data, (uint32_t) dataLen);
+
+    return 0;
+}

--- a/tests/flush_fuzzer.c
+++ b/tests/flush_fuzzer.c
@@ -1,0 +1,87 @@
+/* Derived from zlib fuzzers at http://github.com/google/oss-fuzz/tree/master/projects/zlib,
+ * see ossfuzz.sh for full license text.
+*/
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "miniz.h"
+
+#define CHECK_ERR(err, msg) { \
+    if (err != Z_OK) { \
+        fprintf(stderr, "%s error: %d\n", msg, err); \
+        exit(1); \
+    } \
+}
+
+static const uint8_t *data;
+static size_t dataLen;
+static alloc_func zalloc = NULL;
+static free_func zfree = NULL;
+
+
+void test_flush(unsigned char *compr, size_t *comprLen)
+{
+    z_stream c_stream; /* compression stream */
+    int err;
+    unsigned int len = dataLen;
+
+    c_stream.zalloc = zalloc;
+    c_stream.zfree = zfree;
+    c_stream.opaque = (void *)0;
+
+    err = deflateInit(&c_stream, Z_DEFAULT_COMPRESSION);
+    CHECK_ERR(err, "deflateInit");
+
+    c_stream.next_in = (Bytef *)data;
+    c_stream.next_out = compr;
+    c_stream.avail_in = 3;
+    c_stream.avail_out = (unsigned int)*comprLen;
+    err = deflate(&c_stream, Z_FULL_FLUSH);
+    CHECK_ERR(err, "deflate flush 1");
+
+    compr[3]++; /* force an error in first compressed block */
+    c_stream.avail_in = len - 3;
+
+    err = deflate(&c_stream, Z_FINISH);
+
+    if (err != Z_STREAM_END)
+    {
+        CHECK_ERR(err, "deflate flush 2");
+    }
+
+    err = deflateEnd(&c_stream);
+    CHECK_ERR(err, "deflateEnd");
+
+    *comprLen = (size_t)c_stream.total_out;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size)
+{
+    size_t comprLen = 100 + 2 * compressBound(size);
+    size_t uncomprLen = size;
+    uint8_t *compr, *uncompr;
+
+    /* Discard inputs larger than 1Mb. */
+    static const size_t kMaxSize = 1024 * 1024;
+
+    /* This test requires at least 3 bytes of input data. */
+    if (size <= 3 || size > kMaxSize)
+    return 0;
+
+    data = d;
+    dataLen = size;
+    compr = calloc(1, comprLen);
+    uncompr = calloc(1, uncomprLen);
+
+    test_flush(compr, &comprLen);
+
+    free(compr);
+    free(uncompr);
+
+    return 0;
+}

--- a/tests/fuzz_main.c
+++ b/tests/fuzz_main.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/* Fuzz target entry point for building without libFuzzer */
+
+int main(int argc, char **argv)
+{
+    FILE *f;
+    char *buf = NULL;
+    long siz_buf;
+
+    if(argc < 2)
+    {
+        fprintf(stderr, "no input file\n");
+        goto err;
+    }
+
+    f = fopen(argv[1], "rb");
+    if(f == NULL)
+    {
+        fprintf(stderr, "error opening input file %s\n", argv[1]);
+        goto err;
+    }
+
+    fseek(f, 0, SEEK_END);
+
+    siz_buf = ftell(f);
+    rewind(f);
+
+    if(siz_buf < 1) goto err;
+
+    buf = (char*)malloc(siz_buf);
+    if(buf == NULL)
+    {
+        fprintf(stderr, "malloc() failed\n");
+        goto err;
+    }
+
+    if(fread(buf, siz_buf, 1, f) != 1)
+    {
+        fprintf(stderr, "fread() failed\n");
+        goto err;
+    }
+
+    (void)LLVMFuzzerTestOneInput((uint8_t*)buf, siz_buf);
+
+err:
+    free(buf);
+
+    return 0;
+}

--- a/tests/fuzz_main.c
+++ b/tests/fuzz_main.c
@@ -4,6 +4,8 @@
 
 /* Fuzz target entry point for building without libFuzzer */
 
+int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size);
+
 int main(int argc, char **argv)
 {
     FILE *f;

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -15,6 +15,9 @@
 #
 ################################################################################
 
+# This script is meant to be run by
+# https://github.com/google/oss-fuzz/blob/master/projects/miniz/Dockerfile
+
 mkdir build
 cd build
 cmake .. -DAMALGAMATE_SOURCES=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_FUZZERS=ON

--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir build
+cd build
+cmake .. -DAMALGAMATE_SOURCES=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_FUZZERS=ON
+make -j$(nproc)
+cd ..
+
+zip $OUT/seed_corpus.zip *.*
+
+for f in $(find $SRC -name '*_fuzzer.c'); do
+    b=$(basename -s .c $f)
+    $CC $CFLAGS -Ibuild/amalgamation $f -c -o /tmp/$b.o
+    $CXX $CXXFLAGS -stdlib=libc++ -Ibuild/amalgamation /tmp/$b.o -o $OUT/$b $LIB_FUZZING_ENGINE ./build/libminiz.a
+    rm -f /tmp/$b.o
+    ln -sf $OUT/seed_corpus.zip $OUT/${b}_seed_corpus.zip
+done

--- a/tests/uncompress_fuzzer.c
+++ b/tests/uncompress_fuzzer.c
@@ -14,7 +14,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     unsigned long int buffer_length = sizeof(buffer);
 
-    if (Z_OK != uncompress(buffer, &buffer_length, data, size))) return 0;
+    if (Z_OK != uncompress(buffer, &buffer_length, data, size)) return 0;
     
     return 0;
 }

--- a/tests/uncompress_fuzzer.c
+++ b/tests/uncompress_fuzzer.c
@@ -1,0 +1,20 @@
+/* Derived from zlib fuzzers at http://github.com/google/oss-fuzz/tree/master/projects/zlib,
+ * see ossfuzz.sh for full license text.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "miniz.h"
+
+static unsigned char buffer[256 * 1024] = { 0 };
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    unsigned long int buffer_length = sizeof(buffer);
+
+    if (Z_OK != uncompress(buffer, &buffer_length, data, size))) return 0;
+    
+    return 0;
+}

--- a/tests/uncompress_fuzzer.c
+++ b/tests/uncompress_fuzzer.c
@@ -10,7 +10,7 @@
 
 static unsigned char buffer[256 * 1024] = { 0 };
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     unsigned long int buffer_length = sizeof(buffer);
 


### PR DESCRIPTION
This PR adds multiple fuzz targets for [OSS-Fuzz integration](https://google.github.io/oss-fuzz/architecture/) to automate fuzz testing for this project. Once integrated issues will be automatically filed on bugs.chromium.org when bugs are found and closed when they're fixed.
The project has already been [accepted](https://github.com/google/oss-fuzz/pull/3650) for integration.

The fuzz targets have been integrated into the CMake build with a new `BUILD_FUZZERS` option (defaults to OFF), this can be used to reproduce test cases when built with sanitizers (by setting `CFLAGS=-fsanitize=address`).
 
If this PR is accepted I would handling the rest of the integration, if all goes well a second PR would be made to add a few more fuzzers (e.g. a zip fuzzer similar to `tests/miniz_tester.cpp`).

Usually a contact email is required from a maintainer if integration is done by an outside volunteer, this is used for bug notifications (note: due to some limitations a gmail address is required to access detailed reports), I guessed the contact email when I proposed integration (https://github.com/google/oss-fuzz/blob/master/projects/miniz/project.yaml#L3), @uroni let me know if it should be changed or removed.