### PR TITLE
Fixed use-of-uninitialized value msan error when copying dist bytes

### DIFF
--- a/miniz_tinfl.c
+++ b/miniz_tinfl.c
@@ -498,7 +498,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
                 }
 
                 dist_from_out_buf_start = pOut_buf_cur - pOut_buf_start;
-                if ((dist > dist_from_out_buf_start) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
+                if ((dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
                 {
                     TINFL_CR_RETURN_FOREVER(37, TINFL_STATUS_FAILED);
                 }


### PR DESCRIPTION
It is use-of-uninitialized values because it is copying bytes from the output buffer which hasn't been written to yet. In, `tinfl_decompress` when copying the `counter` number of bytes in the loop the first time around, `pOut_buf_cur == pSrc == pOut_buf_start`. It may require `MINIZ_USE_UNALIGNED_LOADS_AND_STORES` and `MINIZ_UNALIGNED_USE_MEMCPY` to be turned off.

Here is the memory sanitizer error:
```
==60017==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x4c6842 in tinfl_decompress /home/nathan/Source/miniz/build/../miniz_tinfl.c:641:13
    #1 0x4a2d4f in mz_inflate /home/nathan/Source/miniz/build/../miniz.c:466:18
    #2 0x4a8103 in mz_uncompress2 /home/nathan/Source/miniz/build/../miniz.c:574:14
    #3 0x4a8c1d in mz_uncompress /home/nathan/Source/miniz/build/../miniz.c:588:12
    #4 0x4953d8 in main /home/nathan/Source/miniz/build/../msan.c:23:18
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16
    #6 0x41c27d in _start (/home/nathan/Source/miniz/bin/msan+0x41c27d)

  Uninitialized value was stored to memory at
    #0 0x4c6153 in tinfl_decompress /home/nathan/Source/miniz/build/../miniz_tinfl.c:634:20
    #1 0x4a2d4f in mz_inflate /home/nathan/Source/miniz/build/../miniz.c:466:18
    #2 0x4a8103 in mz_uncompress2 /home/nathan/Source/miniz/build/../miniz.c:574:14
    #3 0x4a8c1d in mz_uncompress /home/nathan/Source/miniz/build/../miniz.c:588:12
    #4 0x4953d8 in main /home/nathan/Source/miniz/build/../msan.c:23:18
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was stored to memory at
    #0 0x4c5d6a in tinfl_decompress /home/nathan/Source/miniz/build/../miniz_tinfl.c:631:20
    #1 0x4a2d4f in mz_inflate /home/nathan/Source/miniz/build/../miniz.c:466:18
    #2 0x4a8103 in mz_uncompress2 /home/nathan/Source/miniz/build/../miniz.c:574:14
    #3 0x4a8c1d in mz_uncompress /home/nathan/Source/miniz/build/../miniz.c:588:12
    #4 0x4953d8 in main /home/nathan/Source/miniz/build/../msan.c:23:18
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was stored to memory at
    #0 0x4c17f6 in tinfl_decompress /home/nathan/Source/miniz/build/../miniz_tinfl.c:551:37
    #1 0x4a2d4f in mz_inflate /home/nathan/Source/miniz/build/../miniz.c:466:18
    #2 0x4a8103 in mz_uncompress2 /home/nathan/Source/miniz/build/../miniz.c:574:14
    #3 0x4a8c1d in mz_uncompress /home/nathan/Source/miniz/build/../miniz.c:588:12
    #4 0x4953d8 in main /home/nathan/Source/miniz/build/../msan.c:23:18
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was stored to memory at
    #0 0x4c1690 in tinfl_decompress /home/nathan/Source/miniz/build/../miniz_tinfl.c:550:37
    #1 0x4a2d4f in mz_inflate /home/nathan/Source/miniz/build/../miniz.c:466:18
    #2 0x4a8103 in mz_uncompress2 /home/nathan/Source/miniz/build/../miniz.c:574:14
    #3 0x4a8c1d in mz_uncompress /home/nathan/Source/miniz/build/../miniz.c:588:12
    #4 0x4953d8 in main /home/nathan/Source/miniz/build/../msan.c:23:18
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was stored to memory at
    #0 0x4c152a in tinfl_decompress /home/nathan/Source/miniz/build/../miniz_tinfl.c:549:37
    #1 0x4a2d4f in mz_inflate /home/nathan/Source/miniz/build/../miniz.c:466:18
    #2 0x4a8103 in mz_uncompress2 /home/nathan/Source/miniz/build/../miniz.c:574:14
    #3 0x4a8c1d in mz_uncompress /home/nathan/Source/miniz/build/../miniz.c:588:12
    #4 0x4953d8 in main /home/nathan/Source/miniz/build/../msan.c:23:18
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was stored to memory at
    #0 0x4c1d71 in tinfl_decompress /home/nathan/Source/miniz/build/../miniz_tinfl.c:560:41
    #1 0x4a2d4f in mz_inflate /home/nathan/Source/miniz/build/../miniz.c:466:18
    #2 0x4a8103 in mz_uncompress2 /home/nathan/Source/miniz/build/../miniz.c:574:14
    #3 0x4a8c1d in mz_uncompress /home/nathan/Source/miniz/build/../miniz.c:588:12
    #4 0x4953d8 in main /home/nathan/Source/miniz/build/../msan.c:23:18
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was created by a heap allocation
    #0 0x42845d in malloc (/home/nathan/Source/miniz/bin/msan+0x42845d)
    #1 0x495164 in main /home/nathan/Source/miniz/build/../msan.c:17:25
    #2 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/nathan/Source/miniz/build/../miniz_tinfl.c:641:13 in tinfl_decompress
```
Run cmake using Clang with:
```
cmake . -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -fno-optimize-sibling-calls -g -O0"
```
Here is a simple app that will reproduce the issue:
```
// msan.c
// add_executable(msan msan.c)
// target_link_libraries(msan miniz)

#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>

#include "miniz.h"

int main(void) {
    uint8_t *output;
    uint8_t input[13] = {
        0xf8, 0x00, 0x03, 0x3d, 0x8c, 0x0f,
        0x04, 0x15, 0x00, 0x00, 0x00, 0x00,
        0x00
    };
    unsigned long output_size = 1024;
    int input_size = sizeof(input);

    output = (uint8_t *)malloc(output_size);
    if (output == NULL) {
        printf("Unable to allocate output buffer\n");
        return -1;
    }

    int length = uncompress(output, &output_size, input, input_size);

    if (length > 0)
        printf("Decompressed bytes %d\n", length);
    else
        printf("Unexpected error %d\n", length);

    free(input);
    free(output);
    return length;
}
```

