### PR TITLE
Correct zip64 ZIP archive support limitations entry

### DIFF
--- a/miniz.h
+++ b/miniz.h
@@ -95,7 +95,7 @@
      possibility that the archive's central directory could be lost with this method if anything goes wrong, though.
 
      - ZIP archive support limitations:
-     No zip64 or spanning support. Extraction functions can only handle unencrypted, stored or deflated files.
+     No spanning support. Extraction functions can only handle unencrypted, stored or deflated files.
      Requires streams capable of seeking.
 
    * This is a header file library, like stb_image.c. To get only a header file, either cut and paste the


### PR DESCRIPTION
According to ChangeLog.md Zip64 format is supported since 2.0 release