### PR TITLE
Update meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,3 +13,9 @@ libminiz = static_library('miniz',
 
 miniz_dependency = declare_dependency(link_with: libminiz,
                                       include_directories: miniz_includes)
+                                      
+miniz_dep = miniz_dependency # Compatibility for WrapDB users
+
+if meson.version().version_compare('>= 0.54.0')
+    meson.override_dependency('miniz', miniz_dep)
+endif


### PR DESCRIPTION
Minor improvements to the `meson.build` for newer versions and compatibility for users migrating from the [WrapDB](https://github.com/mesonbuild/miniz/blob/2.1.0/meson.build#L13)  version.