### PR TITLE
Fixed MSAN use-of-uninitialized in tinfl_decompress when invalid dist.

### DIFF
--- a/miniz_tinfl.c
+++ b/miniz_tinfl.c
@@ -498,7 +498,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
                 }
 
                 dist_from_out_buf_start = pOut_buf_cur - pOut_buf_start;
-                if ((dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
+                if ((dist == 0 || dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
                 {
                     TINFL_CR_RETURN_FOREVER(37, TINFL_STATUS_FAILED);
                 }


### PR DESCRIPTION
In this instance `dist` was 31 which `s_dist_base` translates as 0 since the last two entries in the `s_dist_base` is 0.

https://github.com/richgel999/miniz/blob/d6566206ce120069708e77eff79cf117957b419a/miniz_tinfl.c#L490-L492

https://oss-fuzz.com/testcase-detail/4863557237473280

This has also been submitted as Blosc/c-blosc2#215.