### PR TITLE
avoid use of uninitialized value in tdefl_record_literal

### DIFF
--- a/miniz_tdef.c
+++ b/miniz_tdef.c
@@ -1333,6 +1333,7 @@ tdefl_status tdefl_init(tdefl_compressor *d, tdefl_put_buf_func_ptr pPut_buf_fun
     d->m_output_flush_ofs = d->m_output_flush_remaining = d->m_finished = d->m_block_index = d->m_bit_buffer = d->m_wants_to_finish = 0;
     d->m_pLZ_code_buf = d->m_lz_code_buf + 1;
     d->m_pLZ_flags = d->m_lz_code_buf;
+    *d->m_pLZ_flags = 0;
     d->m_num_flags_left = 8;
     d->m_pOutput_buf = d->m_output_buf;
     d->m_pOutput_buf_end = d->m_output_buf;


### PR DESCRIPTION
In `tdefl_record_literal`, the following expression may read an uninitialized value in the `m_pLZ_flags` field:

    *d->m_pLZ_flags = (mz_uint8)(*d->m_pLZ_flags >> 1);

By explicitly initializing the field, we avoid possible undefined behaviors.
Issue found with Frama-C.