### PR TITLE
Fix use of uninitialized memory in tinfl_decompress_mem_to_callback()

### DIFF
--- a/miniz_tinfl.c
+++ b/miniz_tinfl.c
@@ -699,6 +699,7 @@ int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size, 
     size_t in_buf_ofs = 0, dict_ofs = 0;
     if (!pDict)
         return TINFL_STATUS_FAILED;
+    memset(pDict,0,TINFL_LZ_DICT_SIZE);
     tinfl_init(&decomp);
     for (;;)
     {


### PR DESCRIPTION
This patch comes from https://github.com/libxmp/libxmp/pull/436#issuecomment-884977962