### PR TITLE
Fix MinGW cross compilation by removing unneeded capitalization

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -42,7 +42,7 @@ extern "C" {
 #if defined(_MSC_VER) || defined(__MINGW64__)
 
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 static WCHAR* mz_utf8z_to_widechar(const char* str)
 {


### PR DESCRIPTION
Fix MinGW cross compilation by removing unneeded capitalization. Fixes #205 