### PR TITLE
Add switch case for MZ_ZIP_TOTAL_ERRORS

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -4701,6 +4701,8 @@ const char *mz_zip_get_error_string(mz_zip_error mz_err)
             return "validation failed";
         case MZ_ZIP_WRITE_CALLBACK_FAILED:
             return "write calledback failed";
+	case MZ_ZIP_TOTAL_ERRORS:
+            return "total errors";
         default:
             break;
     }


### PR DESCRIPTION
As per comment in https://github.com/richgel999/miniz/blob/842a20e5867345db94162c8dec8ff941bc06e9d6/miniz_zip.h#L117
Fixes issue #223, compiling with `-Werror=switch-enum`.