### PR TITLE
Fix integer overflow in header corruption check.

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -723,7 +723,7 @@ static mz_bool mz_zip_reader_read_central_dir(mz_zip_archive *pZip, mz_uint flag
     if (((num_this_disk | cdir_disk_index) != 0) && ((num_this_disk != 1) || (cdir_disk_index != 1)))
         return mz_zip_set_error(pZip, MZ_ZIP_UNSUPPORTED_MULTIDISK);
 
-    if (cdir_size < pZip->m_total_files * MZ_ZIP_CENTRAL_DIR_HEADER_SIZE)
+    if (cdir_size < (mz_uint64)pZip->m_total_files * MZ_ZIP_CENTRAL_DIR_HEADER_SIZE)
         return mz_zip_set_error(pZip, MZ_ZIP_INVALID_HEADER_OR_CORRUPTED);
 
     if ((cdir_ofs + (mz_uint64)cdir_size) > pZip->m_archive_size)


### PR DESCRIPTION
Hi! I've been fuzzing your project inside pyTorch via model load and found integer overflow error in check for header corruption. The problem is that header may be corrupted or invalid, but because of overflow the check might succeed.
Here is output of sanitizers:

        /pytorch_fuzz/third_party/miniz-2.0.8/miniz.c:3654:41: runtime error: unsigned integer overflow: 4294967295 * 46 cannot be represented in type 'unsigned int'
        SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /pytorch_fuzz/third_party/miniz-2.0.8/miniz.c:3654:41 in

Here is a warning of our tool, which works together with fuzzer, which found an error:

         [2022-05-20 12:09:01.642076] [info] [security]   mz_zip_reader_read_central_dir:/pytorch_sydr/third_party/miniz-2.0.8/miniz.c:3654 - imul ecx, eax, 0x2e - unsigned integer overflow
         [2022-05-20 12:09:01.642134] [info] [security]   mz_zip_reader_read_central_dir:/pytorch_sydr/third_party/miniz-2.0.8/miniz.c:3654 - jb 0x1c72032 - error sink

We modified your code a little bit to prevent the error.