### PR TITLE
pkg-config tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ if(NOT BUILD_HEADER_ONLY)
   if(INSTALL_PROJECT)
     install(FILES
       ${CMAKE_CURRENT_BINARY_DIR}/miniz.pc
-      DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
   endif()
 endif()
 

--- a/miniz.pc.in
+++ b/miniz.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/miniz
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
`/usr/share/pkgconfig` should be used for architecture independent libraries (e.g. data or scripts), while an architecture dependent directory like `/usr/lib64/pkgconfig` should be used for native binaries.

Also set the include path to allow users to include `<miniz.h>` instead of `<miniz/miniz.h>` which seems to be the intended behaviour.