### PR TITLE
Fix -Wshadow warning

### DIFF
--- a/miniz_tdef.c
+++ b/miniz_tdef.c
@@ -627,10 +627,10 @@ static int tdefl_flush_block(tdefl_compressor *d, int flush)
     {
         const mz_uint8 cmf = 0x78;
         mz_uint8 flg, flevel = 3;
-        mz_uint header, i, n = sizeof(s_tdefl_num_probes) / sizeof(mz_uint);
+        mz_uint header, i, c = sizeof(s_tdefl_num_probes) / sizeof(mz_uint);
 
         /* Determine compression level by reversing the process in tdefl_create_comp_flags_from_zip_params() */
-        for (i = 0; i < n; i++)
+        for (i = 0; i < c; i++)
             if (s_tdefl_num_probes[i] == (d->m_flags & 0xFFF)) break;
 
         if (i < 2)


### PR DESCRIPTION
Fixes a `-Wshadow` warning when using miniz as a dependency in a downstream project.
```
miniz.c: In function ‘tdefl_flush_block’:
miniz.c:1278:28: warning: declaration of ‘n’ shadows a previous local [-Wshadow]
 1278 |         mz_uint header, i, n = sizeof(s_tdefl_num_probes) / sizeof(mz_uint);
      |                            ^
miniz.c:1261:9: note: shadowed declaration is here
 1261 |     int n, use_raw_block = ((d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS) != 0) && (d->m_lookahead_pos - d->m_lz_code_buf_dict_pos) <= d->m_dict_size;
      |         ^
```