### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,18 @@ Releases are available at the [releases page](https://github.com/richgel999/mini
 * Entire inflater (including optional zlib header parsing and Adler-32 checking) is implemented in a single function as a coroutine, which is separately available in a small (~550 line) source file: miniz_tinfl.c
 * A fairly complete (but totally optional) set of .ZIP archive manipulation and extraction API's. The archive functionality is intended to solve common problems encountered in embedded, mobile, or game development situations. (The archive API's are purposely just powerful enough to write an entire archiver given a bit of additional higher-level logic.)
 
+## Building miniz - Using vcpkg
+
+You can download and install miniz using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install miniz
+
+The miniz port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Known Problems
 
 * No support for encrypted archives. Not sure how useful this stuff is in practice.


### PR DESCRIPTION
miniz is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for miniz and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build miniz, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/miniz/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)
