### PR TITLE
Update miniz_zip.c

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -48,7 +48,7 @@ static WCHAR* mz_utf8z_to_widechar(const char* str)
 {
   int reqChars = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
   WCHAR* wStr = (WCHAR*)malloc(reqChars * sizeof(WCHAR));
-  MultiByteToWideChar(CP_UTF8, 0, str, -1, wStr, sizeof(WCHAR) * reqChars);
+  MultiByteToWideChar(CP_UTF8, 0, str, -1, wStr, reqChars);
   return wStr;
 }
 


### PR DESCRIPTION
Bugfix: MultiByteToWideChar() is being called with a byte count instead of a character count. This will cause a buffer overrun.