### PR TITLE
Fix missing large file support warning on 64-bit Linux

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -145,7 +145,7 @@ static int mz_stat64(const char *path, struct __stat64 *buffer)
 #define MZ_FREOPEN(p, m, s) freopen64(p, m, s)
 #define MZ_DELETE_FILE remove
 
-#elif defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || (defined(__linux__) && defined(__x86_64__))
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif


### PR DESCRIPTION
Pragmatic approach: Treat Linux on x86_64 the same as Mac OS X and FreeBSD, i.e. as a Unix-like 64-bit operating system with known large file support.

Fixes #257