### PR TITLE
Update miniz_tdef.c to enable compiling in forced-C++ mode

### DIFF
--- a/miniz_tdef.c
+++ b/miniz_tdef.c
@@ -603,7 +603,7 @@ static mz_bool tdefl_compress_block(tdefl_compressor *d, mz_bool static_block)
     return tdefl_compress_lz_codes(d);
 }
 
-static const mz_uint s_tdefl_num_probes[11];
+static const mz_uint s_tdefl_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
 
 static int tdefl_flush_block(tdefl_compressor *d, int flush)
 {
@@ -1461,8 +1461,6 @@ size_t tdefl_compress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const void 
         return 0;
     return out_buf.m_size;
 }
-
-static const mz_uint s_tdefl_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
 
 /* level may actually range from [0,10] (10 is a "hidden" max level, where we want a bit more compression and it's fine if throughput to fall off a cliff on some files). */
 mz_uint tdefl_create_comp_flags_from_zip_params(int level, int window_bits, int strategy)


### PR DESCRIPTION
### Summary:
Merged definition of static const mz_uint s_tdefl_num_probes[11] with its declaration to avoid compilation error when compiling in forced-C++mode

### Details:
When miniz_tdef.c is compiled in C++ mode (either by forcing the compiler to treat the input as C++ or by renaming the file into miniz_tdef.cpp), MSVC17 produces the following error:

> miniz_tdef.cpp(2113,22): error C2086: 'const mz_uint s_tdefl_num_probes[11]': redefinition
> miniz_tdef.cpp(1254,22): message : see declaration of 's_tdefl_num_probes'

This happens because in miniz_tdef.c we have the following:

```
/*Line 606:*/ static const mz_uint s_tdefl_num_probes[11];
/*Line 1465:*/ static const mz_uint s_tdefl_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
```
Such construct is legal in C, but not legal in C++. While miniz_tdef.c is a C source file and not C++, sometimes it is used in C++ projects where settings are such that mixed C/C++ compilation is not allowed and all input source files are treated as forced C++. So there would be no harm to make a small adjustment so that the source code is conformant with both C and C++ requirements.

There are two ways it can be done:

1. Option A: change line 606 from `static const mz_uint s_tdefl_num_probes[11];` to `extern const mz_uint s_tdefl_num_probes[11];`  
2. Option B: move line 1465 into line 606 so that the code looks like this:

```
/*Line 606:*/ static const mz_uint s_tdefl_num_probes[11] = { 0, 1, 6, 32, 16, 32, 128, 256, 512, 768, 1500 };
/*Line 1465:*/ //Nothing here
```
Either option works for both C and C++ and really there is no harm in simply moving the full definition up like in option B and avoid duplication.

This change implements option B. It was also tested and proven to work in amalgamated version.