### PR TITLE
Update miniz.h to correctly reflect release version in the title comment

### DIFF
--- a/miniz.h
+++ b/miniz.h
@@ -1,4 +1,4 @@
-/* miniz.c 3.0.0 - public domain deflate/inflate, zlib-subset, ZIP reading/writing/appending, PNG writing
+/* miniz.c 3.0.2 - public domain deflate/inflate, zlib-subset, ZIP reading/writing/appending, PNG writing
    See "unlicense" statement at the end of this file.
    Rich Geldreich <richgel99@gmail.com>, last updated Oct. 13, 2013
    Implements RFC 1950: http://www.ietf.org/rfc/rfc1950.txt and RFC 1951: http://www.ietf.org/rfc/rfc1951.txt


### PR DESCRIPTION
The version number in the title comment (line 1) was not updated since version 3.0.0, which causes confusion between versions 3.0.0, 3.0.1 and 3.0.2. It would be good if the title comment in this header file was updated for each release as it is exactly that this comment is being looked at by most programmers when checking the library version in their code trees.
