### PR TITLE
Bump cmake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # determine whether this is a standalone project or included by other projects
 set (MINIZ_STANDALONE_PROJECT ON)


### PR DESCRIPTION
`Compatibility with CMake < 3.5 will be removed from a future version of CMake`

Nothing much, just to fix warning in recent CMake versions.