### PR TITLE
Don't redefine `WIN32_LEAN_AND_MEAN` if already defined

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -41,7 +41,9 @@ extern "C" {
 
 #if defined(_MSC_VER) || defined(__MINGW64__) || defined(__MINGW32__)
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+#endif
 #ifndef __cplusplus
   #define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 0
 #endif


### PR DESCRIPTION
This line clashes with other libraries such as [bdwgc](https://github.com/ivmai/bdwgc) or [sokol](https://github.com/floooh/sokol); while they only define the macro if it hasn't been defined before, miniz always `#define`s, which can cause compilation warnings.