### PR TITLE
Remove parameter check in `tinfl_decompress` that breaks `tinfl_decompress_mem_to_heap`

### DIFF
--- a/miniz_tinfl.c
+++ b/miniz_tinfl.c
@@ -203,10 +203,6 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
     size_t out_buf_size_mask = (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF) ? (size_t)-1 : ((pOut_buf_next - pOut_buf_start) + *pOut_buf_size) - 1, dist_from_out_buf_start;
 
     /* Ensure the output buffer's size is a power of 2, unless the output buffer is large enough to hold the entire output file (in which case it doesn't matter). */
-    if ((!pOut_buf_start) || (!pOut_buf_next) || (!pIn_buf_size) || (!pOut_buf_size))
-    {
-        return TINFL_STATUS_BAD_PARAM;
-    }
     if (((out_buf_size_mask + 1) & out_buf_size_mask) || (pOut_buf_next < pOut_buf_start))
     {
         *pIn_buf_size = *pOut_buf_size = 0;


### PR DESCRIPTION
Remove parameter check in tinfl_decompress() that breaks tinfl_decompress_mem_to_heap() as a follow up to the discussion on pull request #268