### PR TITLE
Remove /Zi from MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
   # set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 
   if (MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3 /Zi /permissive-")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3 /permissive-")
   else ()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wshadow -Wformat=2 -Wall -Wno-overlength-strings -pedantic")
   endif ()


### PR DESCRIPTION
This seems like an option better set externally by the user if they desire separate debug info

Furthermore, this prevents building miniz with sccache enabled, see https://github.com/mozilla/sccache/pull/963