### PR TITLE
Move verification out into separate script to fix ARM64 use

### DIFF
--- a/amalgamate.sh
+++ b/amalgamate.sh
@@ -8,26 +8,6 @@ OUTPUT_PREFIX=_build/amalgamation
 
 cmake -H. -B_build -DAMALGAMATE_SOURCES=ON -G"Unix Makefiles"
 
-echo "int main() { return 0; }" > main.c
-echo "Test compile with GCC..."
-gcc -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
-echo "Test compile with GCC ANSI..."
-gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
-if command -v clang
-then
-		echo "Test compile with clang..."
-        clang -Wall -Wpedantic -fsanitize=unsigned-integer-overflow -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
-fi
-for def in MINIZ_NO_STDIO MINIZ_NO_TIME MINIZ_NO_DEFLATE_APIS MINIZ_NO_INFLATE_APIS MINIZ_NO_ARCHIVE_APIS MINIZ_NO_ARCHIVE_WRITING_APIS MINIZ_NO_ZLIB_APIS MINIZ_NO_ZLIB_COMPATIBLE_NAMES MINIZ_NO_MALLOC
-do
-	echo "Test compile with GCC and define $def..."
-	gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -D${def}
-done
-echo "Test compile with GCC and MINIZ_USE_UNALIGNED_LOADS_AND_STORES=1..."
-gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -DMINIZ_USE_UNALIGNED_LOADS_AND_STORES=1
-rm test.out
-rm main.c
-
 cp $OUTPUT_PREFIX/miniz.* amalgamation/
 cp ChangeLog.md amalgamation/
 cp LICENSE amalgamation/

--- a/amalgamate_and_verify.sh
+++ b/amalgamate_and_verify.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+source ./amalgamate.sh
+
+echo "int main() { return 0; }" > main.c
+echo "Test compile with GCC..."
+gcc -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
+echo "Test compile with GCC ANSI..."
+gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
+if command -v clang
+then
+		echo "Test compile with clang..."
+        clang -Wall -Wpedantic -fsanitize=unsigned-integer-overflow -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
+fi
+for def in MINIZ_NO_STDIO MINIZ_NO_TIME MINIZ_NO_DEFLATE_APIS MINIZ_NO_INFLATE_APIS MINIZ_NO_ARCHIVE_APIS MINIZ_NO_ARCHIVE_WRITING_APIS MINIZ_NO_ZLIB_APIS MINIZ_NO_ZLIB_COMPATIBLE_NAMES MINIZ_NO_MALLOC
+do
+	echo "Test compile with GCC and define $def..."
+	gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -D${def}
+done
+echo "Test compile with GCC and MINIZ_USE_UNALIGNED_LOADS_AND_STORES=1..."
+gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -DMINIZ_USE_UNALIGNED_LOADS_AND_STORES=1
+rm test.out
+rm main.c
+
+echo "Amalgamation verified."
+
+
+

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-. amalgamate.sh
+. amalgamate_and_verify.sh
 
 cat << "EOF" > miniz_export.h
 #ifndef MINIZ_EXPORT


### PR DESCRIPTION
Some platforms don't have the clang sanitizer checks available that are used in the verification tests, currently on these the output files can't even be amalgamated. To fix this, separate amalgamation and verification so that the later can be skipped. Fixes #273