### PR TITLE
Fix uninitialized tinfl_init()

### DIFF
--- a/miniz_tinfl.h
+++ b/miniz_tinfl.h
@@ -92,7 +92,7 @@ typedef enum {
 #define tinfl_init(r)     \
     do                    \
     {                     \
-        (r)->m_state = 0; \
+        memset(r, 0, sizeof (tinfl_decompressor)); \
     }                     \
     MZ_MACRO_END
 #define tinfl_get_adler32(r) (r)->m_check_adler32


### PR DESCRIPTION
Fixes GH #296.
Found by cppcheck