### PR TITLE
Add batch script to build amalgamation on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /_build
 /amalgamation
 /bin
+amalgamate_config.txt

--- a/amalgamate.bat
+++ b/amalgamate.bat
@@ -1,0 +1,43 @@
+@echo off
+setlocal
+
+if not exist "amalgamate_config.txt" (
+echo Configuration file not found. Creating a default amalgamate_config.txt...
+echo # Default Configuration >amalgamate_config.txt
+echo compiler_path=C:\Path\To\Compiler >>amalgamate_config.txt
+echo cmake_generator=MinGW Makefiles >>amalgamate_config.txt
+echo Please edit amalgamate_config.txt to match your environment before rerunning this script.
+goto end
+)
+
+for /f "tokens=1,* delims==" %%a in (amalgamate_config.txt) do (
+if /i "%%a"=="compiler_path" set "compiler_path=%%b"
+if /i "%%a"=="cmake_generator" set "cmake_generator=%%b"
+)
+
+if "%compiler_path%"=="" (
+echo Compiler path not set in amalgamate_config.txt. Please specify the compiler path.
+goto end
+)
+
+if "%cmake_generator%"=="" (
+echo CMake generator not set in amalgamate_config.txt. Please specify the CMake generator.
+goto end
+)
+
+echo Configuration Loaded:
+echo Compiler Path: %compiler_path%
+echo CMake Generator: %cmake_generator%
+set path=%compiler_path%;%path%
+if not exist amalgamation mkdir amalgamation
+if not exist _build\amalgamation mkdir _build\amalgamation
+cmake -H. -B_build -DAMALGAMATE_SOURCES=ON -G "%cmake_generator%" >>amalgamate_results.log 2>&1
+xcopy /Y /I _build\amalgamation\miniz.* amalgamation\
+copy /Y ChangeLog.md amalgamation\
+copy /Y LICENSE amalgamation\
+copy /Y readme.md amalgamation\
+if not exist amalgamation\examples mkdir amalgamation\examples
+xcopy /Y /I examples\* amalgamation\examples\
+
+:end
+endlocal

--- a/amalgamate_config_template.txt
+++ b/amalgamate_config_template.txt
@@ -1,0 +1,4 @@
+# Default Configuration Template for Amalgamation
+# Copy this to amalgamate_config.txt and customize it as needed.
+compiler_path=C:\Path\To\Compiler
+cmake_generator=MinGW Makefiles

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ Miniz is a lossless, high performance data compression library in a single sourc
 
 Releases are available at the [releases page](https://github.com/richgel999/miniz/releases) as a pair of `miniz.c`/`miniz.h` files which can be simply added to a project. To create this file pair the different source and header files are [amalgamated](https://www.sqlite.org/amalgamation.html) during build. Alternatively use as cmake or meson module (or build system of your choice).
 
+If you wish to build the amalgamations yourself, there are scripts to do this. If you are using Bash, simply run amalgamate.sh. If you are using Windows, you can add your compiler settings to amalgamate_config.txt and then run amalgamate.bat.
+
 ## Features
 
 * MIT licensed


### PR DESCRIPTION
Implemented a batch script to simplify the building of the amalgamation on Windows. This script is based on the existing bash script with a few key alterations. The zipping procedure has been removed since Windows doesn't ship with a native "zip" utility. It also enhances the setup by reading necessary values from a configuration file (amalgamate_config.txt), addressing the common
Windows challenge of managing multiple compiler installations without hardcoding paths.

To ensure all local settings remain user-specific, amalgamate_config.txt has been added to .gitignore, and an example configuration file (amalgamate_config_template.txt) is provided to facilitate easy initial setup for developers.