### PR TITLE
Read comp_size, decomp_size and local_header_ofs for zip64 if extra fields exist

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -916,7 +916,9 @@ static int mz_stat64(const char *path, struct __stat64 *buffer)
                             pExtra_data += sizeof(mz_uint16) * 2 + field_data_size;
                             extra_size_remaining = extra_size_remaining - sizeof(mz_uint16) * 2 - field_data_size;
                         } while (extra_size_remaining);
-
+                        // Read zip64 extended information field into comp_size and decomp_size
+                        comp_size = MZ_READ_LE64(pExtra_data + sizeof(mz_uint16) * 2);
+                        decomp_size = MZ_READ_LE64(pExtra_data + sizeof(mz_uint16) * 2 + sizeof(mz_uint64));
                         MZ_FREE(buf);
                     }
                 }


### PR DESCRIPTION
As titled. For a zip64 archive file, `comp_size`, `decomp_size` and `local_header_ofs` are not stored in `p + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS`, instead they are being stored in `pExtra_data`.

Here we need to read `uint64` for `comp_size`, `decomp_size` and `local_header_ofs`. Good that they are already of that type.

Reference: https://en.wikipedia.org/wiki/ZIP_(file_format)#ZIP64