### PR TITLE
Remedy CVE-2018-12913

### DIFF
--- a/.github/workflows/ci-fuzz.yml
+++ b/.github/workflows/ci-fuzz.yml
@@ -16,7 +16,7 @@ jobs:
         fuzz-seconds: 900
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: artifacts

--- a/miniz_tinfl.c
+++ b/miniz_tinfl.c
@@ -491,7 +491,7 @@ extern "C"
                             bit_buf >>= code_len;
                             num_bits -= code_len;
                         
-                        //assert(sym2 != 0 && counter != 0);
+                        /* assert(sym2 != 0 && counter != 0); */
                         if (sym2 == 0 && counter == 0)
                         {
                             TINFL_CR_RETURN_FOREVER(40, TINFL_STATUS_FAILED);

--- a/miniz_tinfl.c
+++ b/miniz_tinfl.c
@@ -490,6 +490,12 @@ extern "C"
                             }
                             bit_buf >>= code_len;
                             num_bits -= code_len;
+                        
+                        //assert(sym2 != 0 && counter != 0);
+                        if (sym2 == 0 && counter == 0)
+                        {
+                            TINFL_CR_RETURN_FOREVER(40, TINFL_STATUS_FAILED);
+                        }
 
                             pOut_buf_cur[0] = (mz_uint8)counter;
                             if (sym2 & 256)


### PR DESCRIPTION
This was originally reported in #90 which was closed without any remediation. 

This can be reproduced by downloading the POC from here:
https://github.com/Edward-L/my-cve-list/blob/master/miniz/dos-an-infinite-loop-miniz_tinfl-c-398.poc

Uncomment the `assert` in the `miniz_tinfl.c` line 494, build the project.

And then run the `example3.exe` as shown with debugger:

```
example3.exe d, "C:\Temp\dos-an-infinite-loop-miniz_tinfl-c-398.poc" "C:\Temp\Bad.txt"
```

Because the POC file used as the input is not a valid zip file, we should not be attempting to extract it. However, as a guard against other zip files that may be maliciously crafted, we've added the condition  and throw an error if both `sym2` and `counter` are zero. 