### PR TITLE
CMakeLists.txt: only require a C compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,10 @@ if(DEFINED PROJECT_NAME)
 endif()
 
 if(CMAKE_MINOR_VERSION LESS 12)
-  project(miniz)
+  project(miniz C)
   # see issue https://gitlab.kitware.com/cmake/cmake/merge_requests/1799
 else()
-  project(miniz)
+  project(miniz C)
   set(CMAKE_C_STANDARD 90)
   set(CMAKE_VERBOSE_MAKEFILE ON)
   # set(CMAKE_C_VISIBILITY_PRESET hidden)
@@ -309,6 +309,7 @@ if(BUILD_FUZZERS)
 endif()
 
 if(BUILD_TESTS)
+  enable_language(CXX)
   set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED YES)
 


### PR DESCRIPTION
Commit 05ab4dc05c9d1e1f951f5849b659e2c7e291a620
"Add some catch2 tests" dropped that C flag,
but should instead only have added a simple
enable_language call for tests only.