### PR TITLE
fix: use more complete version test for CMake < 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(DEFINED PROJECT_NAME)
   set(MINIZ_STANDALONE_PROJECT OFF)
 endif()
 
-if(CMAKE_MINOR_VERSION LESS 12)
+if(CMAKE_VERSION VERSION_LESS "3.12")
   project(miniz)
   # see issue https://gitlab.kitware.com/cmake/cmake/merge_requests/1799
 else()


### PR DESCRIPTION
The prior version check assumed a major version of 3, which naturally means it failed with the new CMake v4.0. This updates the check to now properly consider the full version number, and allow usage with CMake 4.0 and later. 