### PR TITLE
Fix CMake minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5..3.12)
+cmake_minimum_required(VERSION 3.5...3.12)
 
 # determine whether this is a standalone project or included by other projects
 set (MINIZ_STANDALONE_PROJECT ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5..3.12)
 
 # determine whether this is a standalone project or included by other projects
 set (MINIZ_STANDALONE_PROJECT ON)


### PR DESCRIPTION
Latest CMake (4.0.1) outputs an error while building miniz from source:
```
Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
  ```
  This patch shouldn't break any backwards compatibility, but fixes this error for current CMake versions