### PR TITLE
[examples/example{2,3,4,5}.c] MSVC fixes

### DIFF
--- a/examples/example2.c
+++ b/examples/example2.c
@@ -39,11 +39,16 @@ int main(int argc, char *argv[])
     mz_zip_archive zip_archive;
     void *p;
     const int N = 50;
-    char data[2048];
-    char archive_filename[64];
+    enum
+    {
+        archive_filename_len = 64,
+        data_len = 2048
+    };
+    char data[data_len];
+    char archive_filename[archive_filename_len];
     static const char *s_Test_archive_filename = "__mz_example2_test__.zip";
 
-    assert((strlen(s_pTest_str) + 64) < sizeof(data));
+    assert((strlen(s_pTest_str) + archive_filename_len) < sizeof(data));
 
     printf("miniz.c version: %s\n", MZ_VERSION);
 
@@ -55,9 +60,13 @@ int main(int argc, char *argv[])
     // Append a bunch of text files to the test archive
     for (i = (N - 1); i >= 0; --i)
     {
+#ifdef _MSC_VER
+        sprintf_s(archive_filename, archive_filename_len, "%u.txt", i);
+        sprintf_s(data, data_len, "%u %s %u", (N - 1) - i, s_pTest_str, i);
+#else
         sprintf(archive_filename, "%u.txt", i);
         sprintf(data, "%u %s %u", (N - 1) - i, s_pTest_str, i);
-
+#endif
         // Add a new file to the archive. Note this is an IN-PLACE operation, so if it fails your archive is probably hosed (its central directory may not be complete) but it should be recoverable using zip -F or -FF. So use caution with this guy.
         // A more robust way to add a file to an archive would be to read it into memory, perform the operation, then write a new archive out to a temp file and then delete/rename the files.
         // Or, write a new archive to disk to a temp file, then delete/rename the files. For this test this API is fine.
@@ -127,8 +136,13 @@ int main(int argc, char *argv[])
 
         for (i = 0; i < N; i++)
         {
+#ifdef _MSC_VER
+            sprintf_s(archive_filename, archive_filename_len, "%u.txt", i);
+            sprintf_s(data, data_len, "%u %s %u", (N - 1) - i, s_pTest_str, i);
+#else
             sprintf(archive_filename, "%u.txt", i);
             sprintf(data, "%u %s %u", (N - 1) - i, s_pTest_str, i);
+#endif
 
             // Try to extract all the files to the heap.
             p = mz_zip_reader_extract_file_to_heap(&zip_archive, archive_filename, &uncomp_size, 0);

--- a/examples/example3.c
+++ b/examples/example3.c
@@ -88,12 +88,23 @@ int main(int argc, char *argv[])
     printf("Mode: %c, Level: %u\nInput File: \"%s\"\nOutput File: \"%s\"\n", pMode[0], level, pSrc_filename, pDst_filename);
 
     // Open input file.
+#if defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__
+    {
+        const errno_t err = fopen_s(&pInfile, pSrc_filename, "rb");;
+        if (err != 0 || pInfile == NULL) {
+            fprintf(stderr, "Failed to open %s for reading", pSrc_filename);
+            free(pInfile);
+            return EXIT_FAILURE;
+        }
+    }
+#else
     pInfile = fopen(pSrc_filename, "rb");
     if (!pInfile)
     {
         printf("Failed opening input file!\n");
         return EXIT_FAILURE;
     }
+#endif /* defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ */
 
     // Determine input file's size.
     fseek(pInfile, 0, SEEK_END);
@@ -110,12 +121,23 @@ int main(int argc, char *argv[])
     infile_size = (uint)file_loc;
 
     // Open output file.
+#if defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__
+    {
+        const errno_t err = fopen_s(&pOutfile, pDst_filename, "wb");;
+        if (err != 0 || pInfile == NULL) {
+            fprintf(stderr, "Failed to open %s for writing", pDst_filename);
+            free(pOutfile);
+            return EXIT_FAILURE;
+        }
+    }
+#else
     pOutfile = fopen(pDst_filename, "wb");
     if (!pOutfile)
     {
         printf("Failed opening output file!\n");
         return EXIT_FAILURE;
     }
+#endif /* defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ */
 
     printf("Input file size: %u\n", infile_size);
 

--- a/examples/example4.c
+++ b/examples/example4.c
@@ -35,12 +35,23 @@ int main(int argc, char *argv[])
     }
 
     // Open input file.
+#if defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__
+    {
+        const errno_t err = fopen_s(&pInfile, argv[1], "rb");;
+        if (err != 0 || pInfile == NULL) {
+            fprintf(stderr, "Failed to open %s for reading", argv[1]);
+            free(pInfile);
+            return EXIT_FAILURE;
+        }
+    }
+#else
     pInfile = fopen(argv[1], "rb");
     if (!pInfile)
     {
         printf("Failed opening input file!\n");
         return EXIT_FAILURE;
     }
+#endif /* defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ */
 
     // Determine input file's size.
     fseek(pInfile, 0, SEEK_END);
@@ -69,12 +80,23 @@ int main(int argc, char *argv[])
     }
 
     // Open output file.
+#if defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__
+    {
+        const errno_t err = fopen_s(&pOutfile, argv[2], "wb");;
+        if (err != 0 || pInfile == NULL) {
+            fprintf(stderr, "Failed to open %s for writing", argv[2]);
+            free(pOutfile);
+            return EXIT_FAILURE;
+        }
+    }
+#else
     pOutfile = fopen(argv[2], "wb");
     if (!pOutfile)
     {
         printf("Failed opening output file!\n");
         return EXIT_FAILURE;
     }
+#endif /* defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ */
 
     printf("Input file size: %u\n", infile_size);
 

--- a/examples/example5.c
+++ b/examples/example5.c
@@ -120,12 +120,23 @@ int main(int argc, char *argv[])
     printf("Mode: %c, Level: %u\nInput File: \"%s\"\nOutput File: \"%s\"\n", pMode[0], level, pSrc_filename, pDst_filename);
 
     // Open input file.
+#if defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__
+    {
+        const errno_t err = fopen_s(&pInfile, pSrc_filename, "rb");;
+        if (err != 0 || pInfile == NULL) {
+            fprintf(stderr, "Failed to open %s for reading", pSrc_filename);
+            free(pInfile);
+            return EXIT_FAILURE;
+        }
+    }
+#else
     pInfile = fopen(pSrc_filename, "rb");
     if (!pInfile)
     {
         printf("Failed opening input file!\n");
         return EXIT_FAILURE;
     }
+#endif /* defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ */
 
     // Determine input file's size.
     fseek(pInfile, 0, SEEK_END);
@@ -142,12 +153,23 @@ int main(int argc, char *argv[])
     infile_size = (uint)file_loc;
 
     // Open output file.
+#if defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__
+    {
+        const errno_t err = fopen_s(&pOutfile, pDst_filename, "wb");;
+        if (err != 0 || pInfile == NULL) {
+            fprintf(stderr, "Failed to open %s for writing", pDst_filename);
+            free(pOutfile);
+            return EXIT_FAILURE;
+        }
+    }
+#else
     pOutfile = fopen(pDst_filename, "wb");
     if (!pOutfile)
     {
         printf("Failed opening output file!\n");
         return EXIT_FAILURE;
     }
+#endif /* defined(_MSC_VER) || defined(__STDC_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ */
 
     printf("Input file size: %u\n", infile_size);
 


### PR DESCRIPTION
Lots of warnings building on MSVC. This resolves all of them except:
```
miniz\examples\example6.c(146): warning C4333: '>>': right shift by too large amount, data loss
```

```c
color[1] = (uint8)Iteration >> 8;
```
https://github.com/richgel999/miniz/blob/8714fd3/examples/example6.c#L146