### PR TITLE
fix unininitialized access in tdefl_record_literal

### DIFF
--- a/miniz_tdef.c
+++ b/miniz_tdef.c
@@ -1065,6 +1065,7 @@ static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahe
         {
             d->m_num_flags_left = 8;
             d->m_pLZ_flags = d->m_pLZ_code_buf++;
+            *(d->m_pLZ_flags) = 0;
         }
         d->m_huff_count[0][lit]++;
     }
@@ -1089,6 +1090,7 @@ static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahe
         {
             d->m_num_flags_left = 8;
             d->m_pLZ_flags = d->m_pLZ_code_buf++;
+            *(d->m_pLZ_flags) = 0;
         }
 
         s0 = s_tdefl_small_dist_sym[match_dist & 511];


### PR DESCRIPTION
This is a follow-up from #189 and was also found while analyzing the code with Frama-C/Eva abstract interpreter. Actually, in `tdefl_record_literal`, `d->m_pLZ_flags` can point to the successive elements of `d->m_lz_code_buf`, and the PR mentioned above only initializes the first one. The proposed patch is to initialize each element to `0` as soon as we increment `d->m_pLZ_flags`.

An alternative solution would of course consist in `memset`ing the entire array to `0` in `tdefl_init` instead of initializing only the first element.