### PR TITLE
amalgamate.sh: SKIPTESTS and CCPREFIX env vars added

### DIFF
--- a/amalgamate.sh
+++ b/amalgamate.sh
@@ -8,25 +8,28 @@ OUTPUT_PREFIX=_build/amalgamation
 
 cmake -H. -B_build -DAMALGAMATE_SOURCES=ON -G"Unix Makefiles"
 
+if [ "${SKIPTESTS:-0}" != "1" ]; then
+
 echo "int main() { return 0; }" > main.c
 echo "Test compile with GCC..."
-gcc -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
+${CCPREFIX}gcc -pedantic -Wall -Wno-unused-function -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
 echo "Test compile with GCC ANSI..."
-gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
-if command -v clang
-then
-		echo "Test compile with clang..."
-        clang -Wall -Wpedantic -fsanitize=unsigned-integer-overflow -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
+${CCPREFIX}gcc -ansi -pedantic -Wall -Wno-unused-function -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
+if command -v clang; then
+        echo "Test compile with clang..."
+        clang -Wall -Wno-unused-function -Wpedantic -fsanitize=unsigned-integer-overflow -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out
 fi
 for def in MINIZ_NO_STDIO MINIZ_NO_TIME MINIZ_NO_DEFLATE_APIS MINIZ_NO_INFLATE_APIS MINIZ_NO_ARCHIVE_APIS MINIZ_NO_ARCHIVE_WRITING_APIS MINIZ_NO_ZLIB_APIS MINIZ_NO_ZLIB_COMPATIBLE_NAMES MINIZ_NO_MALLOC
 do
 	echo "Test compile with GCC and define $def..."
-	gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -D${def}
+	${CCPREFIX}gcc -ansi -pedantic -Wall -Wno-unused-function -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -D${def}
 done
 echo "Test compile with GCC and MINIZ_USE_UNALIGNED_LOADS_AND_STORES=1..."
-gcc -ansi -pedantic -Wall -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -DMINIZ_USE_UNALIGNED_LOADS_AND_STORES=1
+${CCPREFIX}gcc -ansi -pedantic -Wall -Wno-unused-function -I$OUTPUT_PREFIX main.c $OUTPUT_PREFIX/miniz.c -o test.out -DMINIZ_USE_UNALIGNED_LOADS_AND_STORES=1
 rm test.out
 rm main.c
+
+fi # SKIP TESTS WHEN AREN'T USEFUL
 
 cp $OUTPUT_PREFIX/miniz.* amalgamation/
 cp ChangeLog.md amalgamation/
@@ -53,5 +56,4 @@ EOF
 cd ..
 
 echo "Amalgamation created."
-
 


### PR DESCRIPTION
In cross compiling enviroment when almalgamate is useld (or supposed to be) introducing CCPREFIX and SKIPTESTS enviroment variable to control amalgamate.sh seems useful.